### PR TITLE
add validation options to allow resolvers not in schema

### DIFF
--- a/src/lib/schemaParser.js
+++ b/src/lib/schemaParser.js
@@ -11,6 +11,9 @@ module.exports = function (schemaString, dataSourcesJson, resolverMappingsJson, 
   const schema = makeExecutableSchema({
     typeDefs: [schemaString],
     resolvers: resolvers,
+    resolverValidationOptions: {
+      allowResolversNotInSchema: true
+    },
     schemaDirectives
   })
   return {schema, dataSources}


### PR DESCRIPTION
## Motivation
https://issues.jboss.org/browse/AEROGEAR-7900

## What
Need to allow resolvers to be defined in the db without necessarily being in the schema.

## Why
Otherwise an error will be thrown when a query is renamed etc.

## How
Using an option available in makeExecutableSchema.

## Verification Steps
1) In the UI, edit the name of query. This resolver will stay in the db even though it is now 'dangling'.
2) No errors should be shown in the console.

